### PR TITLE
fix: dialog state de-sync when closing via `Esc` key

### DIFF
--- a/src/components/header/menu/Menu.tsx
+++ b/src/components/header/menu/Menu.tsx
@@ -15,6 +15,11 @@ function Menu() {
 
   const onMenuOpen = () => {
     flushSync(() => setDialogIsOpen(true));
+
+    // Ensure that the dialog closes properly when pressing `Esc`
+    // in the dialog.
+    dialogRef.current?.addEventListener("cancel", onMenuClose, { once: true });
+
     dialogRef.current?.showModal();
   };
 
@@ -36,13 +41,6 @@ function Menu() {
         "change",
         onDesktopScreenSizes
       );
-  }, []);
-
-  // Sync `dialogIsOpen` state when
-  // ESC is pressed from dialog.
-  useEffect(() => {
-    dialogRef.current?.addEventListener("cancel", onMenuClose);
-    return () => dialogRef.current?.removeEventListener("cancel", onMenuClose);
   }, []);
 
   return (


### PR DESCRIPTION
**Description**
- The bug stemmed from trying to add `onMenuClose` as an event handler for the menu dialog's `cancel` event on `<Menu>` component mount. By the time that `useEffect` runs and tries to add it, the `dialogRef` is still `null` because `<MenuDialog>` is conditionally rendered based on the `dialogIsOpen` state variable (`false` until dialog is manually opened by user). Therefore, the event listener is added to a `null` object and when the dialog is actually opened, it will have no accompanying event handler for the `cancel` event and won't sync the dialog open/close state when closed with the `Esc` key; thus, resulting in the broken visual state.

- This PR will fix this issue: #1 